### PR TITLE
Improve exception handling

### DIFF
--- a/src/main/java/org/fedorahosted/tennera/jgettext/PoParser.java
+++ b/src/main/java/org/fedorahosted/tennera/jgettext/PoParser.java
@@ -74,7 +74,7 @@ public class PoParser {
         try {
             parser.catalog();
         } catch (RecognitionException e) {
-            throw new UnexpectedTokenException(e.getMessage(), e.getLine());
+            throw new UnexpectedTokenException(e.getMessage(), e, e.getLine());
         } catch (TokenStreamException e) {
             throw new ParseException(e.getMessage(), e, -1);
         }

--- a/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/CatalogLexer.java
+++ b/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/CatalogLexer.java
@@ -306,7 +306,7 @@ public class CatalogLexer implements TokenStream, CatalogTokenTypes {
                 String line = ioReader.readLine();
                 return line;
             } catch (IOException e) {
-                throw new ParseException("unable to read line", lineNumber());
+                throw new ParseException("unable to read line", e, lineNumber());
             }
         }
 

--- a/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/ExtendedCatalogParser.java
+++ b/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/ExtendedCatalogParser.java
@@ -92,10 +92,7 @@ public class ExtendedCatalogParser extends CatalogParser {
 
     @Override
     public void reportError(RecognitionException e) {
-        UnexpectedTokenException utEx =
-                new UnexpectedTokenException(e.getMessage(), e.getLine());
-        utEx.initCause(e);
-        throw utEx;
+        throw new UnexpectedTokenException(e.getMessage(), e, e.getLine());
     }
 
     @Override

--- a/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/MessageStreamParser.java
+++ b/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/MessageStreamParser.java
@@ -76,10 +76,7 @@ public class MessageStreamParser {
         }
 
         public void reportError(RecognitionException e) {
-            UnexpectedTokenException utEx =
-                    new UnexpectedTokenException(e.getMessage(), e.getLine());
-            utEx.initCause(e);
-            throw utEx;
+            throw new UnexpectedTokenException(e.getMessage(), e, e.getLine());
         }
 
         public void reportError(String s) {

--- a/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/ParseException.java
+++ b/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/ParseException.java
@@ -35,7 +35,9 @@ public class ParseException extends RuntimeException {
         this.line = line;
     }
 
-    public String toString() {
-        return super.toString() + " [line=" + line + "]";
+    @Override
+    public String getMessage() {
+        String msg = super.getMessage();
+        return (msg != null ? msg + " " : "") + "[line=" + line + "]";
     }
 }

--- a/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/UnexpectedTokenException.java
+++ b/src/main/java/org/fedorahosted/tennera/jgettext/catalog/parse/UnexpectedTokenException.java
@@ -26,4 +26,8 @@ public class UnexpectedTokenException extends ParseException {
     public UnexpectedTokenException(String message, int line) {
         super(message, line);
     }
+
+    public UnexpectedTokenException(String message, Throwable cause, int line) {
+        super(message, cause, line);
+    }
 }


### PR DESCRIPTION
We currently lose the details of some IOExceptions during parsing. This should help.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/jgettext/6)
<!-- Reviewable:end -->
